### PR TITLE
feat: Open Draaft Page in Browser on Login

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,10 @@ jar {
 	}
 }
 
+loom {
+	accessWidenerPath = file("src/main/resources/draaft.accesswidener")
+}
+
 // configure the maven publication
 publishing {
 	publications {

--- a/src/main/java/draaft/client/ServerClient.java
+++ b/src/main/java/draaft/client/ServerClient.java
@@ -53,7 +53,7 @@ public class ServerClient {
     }
 
     // thanks menx :)
-    public void draaftLogin(/* :) */) {
+    public String draaftLogin(/* :) */) {
         MinecraftClient inst = MinecraftClient.getInstance();
         Session session = inst.getSession();
         // okay: then we add a "generate room" button ingame and it gives you a key
@@ -66,15 +66,15 @@ public class ServerClient {
         } catch (AuthenticationUnavailableException var3) {
             LOGGER.warn("disconnect.loginFailedInfo: disconnect.loginFailedInfo.serversUnavailable");
             connectingStatus = "Error: Servers unavailable!";
-            return;
+            return null;
         } catch (InvalidCredentialsException var4) {
             LOGGER.warn("disconnect.loginFailedInfo: disconnect.loginFailedInfo.invalidSession");
             connectingStatus = "Error: Invalid session!";
-            return;
+            return null;
         } catch (AuthenticationException authenticationException) {
             LOGGER.warn("disconnect.loginFailedInfo {}", authenticationException.getMessage());
             connectingStatus = authenticationException.getMessage();
-            return;
+            return null;
         }
         connectingStatus = "Contacting drAAft server...";
         String username = session.getUsername();
@@ -94,7 +94,7 @@ public class ServerClient {
         } catch (IOException | InterruptedException | URISyntaxException e) {
             LOGGER.warn("Could not contact drAAft server: {}", e.getMessage());
             connectingStatus = "Error contacting drAAft server!";
-            return;
+            return null;
         }
 
         /*
@@ -116,5 +116,6 @@ public class ServerClient {
         clipboard.setClipboard(MinecraftClient.getInstance().getWindow().getHandle(), clientToken);
 
         connectingStatus = "Connected! Password copied to clipboard.";
+        return clientToken;
     }
 }

--- a/src/main/java/draaft/draaft.java
+++ b/src/main/java/draaft/draaft.java
@@ -18,6 +18,7 @@ public class draaft implements ModInitializer {
 	public static final String MOD_ID = "draaft";
 	public static final Logger LOGGER = LogManager.getLogger(MOD_ID);
 	public static final String DRAAFT_VERSION = getDraaftVersion();
+	public static final String BACKEND_SERVER_URL = "http://localhost:8080/src/draaft";
 
 	@Override
 	public void onInitialize() {

--- a/src/main/java/draaft/mixin/client/gui/TitleScreenMixin.java
+++ b/src/main/java/draaft/mixin/client/gui/TitleScreenMixin.java
@@ -3,6 +3,7 @@ package draaft.mixin.client.gui;
 import draaft.client.ServerClient;
 import me.contaria.speedrunapi.util.TextUtil;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.ConfirmChatLinkScreen;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.TitleScreen;
 import net.minecraft.client.gui.widget.ButtonWidget;
@@ -14,16 +15,26 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static draaft.draaft.BACKEND_SERVER_URL;
+import static draaft.draaft.MOD_ID;
+
 @Mixin(TitleScreen.class)
 public abstract class TitleScreenMixin extends Screen {
     @Unique
     private static final String DEFAULT_BUTTON_HOVER = "drAAft Login";
+    @Unique
+    private static final Logger LOGGER = LogManager.getLogger(MOD_ID);
 
     protected TitleScreenMixin(Text title) {
         super(title);
@@ -48,7 +59,26 @@ public abstract class TitleScreenMixin extends Screen {
             login_button_width,
             login_button_heigh,
             LiteralText.EMPTY,
-            button -> { ServerClient.getInstance().draaftLogin(); })
+            button -> {
+                String clientToken = ServerClient.getInstance().draaftLogin();
+
+                if(clientToken != null) {
+                    // Link opening code adapted from net.minecraft.client.gui.screen.Screen.handleTextClick
+                    String url = BACKEND_SERVER_URL + "/index.html?token=" + clientToken;
+                    try {
+                        URI uRI = new URI(url);
+                        if (this.client != null && this.client.options.chatLinksPrompt) {
+                            this.clickedLink = uRI;
+                            String censoredUrl = BACKEND_SERVER_URL + "/index.html";
+                            this.client.openScreen(new ConfirmChatLinkScreen(this::confirmLink, censoredUrl, true));
+                        } else {
+                            openLink(uRI);
+                        }
+                    } catch (URISyntaxException e) {
+                        LOGGER.error("Failed to open URL", e);
+                    }
+                }
+            })
         {
             @Override
             public void renderButton(MatrixStack matrices, int mouseX, int mouseY, float delta) {

--- a/src/main/resources/draaft.accesswidener
+++ b/src/main/resources/draaft.accesswidener
@@ -1,0 +1,4 @@
+accessWidener v2 named
+accessible method net/minecraft/client/gui/screen/Screen openLink (Ljava/net/URI;)V
+accessible method net/minecraft/client/gui/screen/Screen confirmLink (Z)V
+accessible field net/minecraft/client/gui/screen/Screen clickedLink Ljava/net/URI;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -26,6 +26,8 @@
 	"depends": {
 		"fabricloader": ">=0.16.13",
 		"minecraft": "~1.16.1",
-		"java": ">=8"
-	}
+		"java": ">=8",
+		"speedrunapi": ">=2.0+1.16.1"
+	},
+	"accessWidener": "draaft.accesswidener"
 }


### PR DESCRIPTION
This PR opens the the Draaft page in the browser and automatically logs in using the token as a query parameter when the user clicks the enchanted bucket log in button. There will be a corresponding PR on the website to support the token parm.

The behaviour of confirming to open the link can be removed if it is undesirable. 