### PR TITLE
Custom development web & API URIs

### DIFF
--- a/src/main/java/draaft/client/AuthTokenServer.java
+++ b/src/main/java/draaft/client/AuthTokenServer.java
@@ -8,33 +8,30 @@ import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
 /**
  * An HTTP server serving tokens to the frontend
  */
 public class AuthTokenServer {
-    public String token = "";
-
     private final HttpServer server;
-    private final Gson gson = new Gson();
+    private final DraaftServices draaftServices;
+    private final String token;
 
-    private static final AuthTokenServer INSTANCE;
+    public AuthTokenServer(DraaftServices draaftServices, String token) {
+        this.draaftServices = draaftServices;
+        this.token = token;
 
-    static {
-		try {
-            INSTANCE = new AuthTokenServer();
-		} catch (IOException e) {
-			throw new RuntimeException("failed to create an HTTP server", e);
-		}
-	}
-
-    private AuthTokenServer() throws IOException {
         // Bind to any ephemeral free port, listen only for local connections
         var bindAddr = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
 
-        // 0 indicates the default backlog size
-        this.server = HttpServer.create(bindAddr, 0);
+        try {
+            // 0 indicates the default backlog size
+            this.server = HttpServer.create(bindAddr, 0);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create an HTTP server for auth token passing", e);
+        }
 
         this.server.createContext("/", new Handler());
 
@@ -42,15 +39,15 @@ public class AuthTokenServer {
         this.server.start();
     }
 
+    public String webLoginUri() {
+        return "%s?auth_port=%d".formatted(this.draaftServices.webBase().toString(), this.port());
+    }
+
     /**
      * @return the port the server is listening on.
      */
-    public int port() {
+    private int port() {
         return this.server.getAddress().getPort();
-    }
-
-    public static AuthTokenServer get() {
-        return INSTANCE;
     }
 
     record Response(String token) {}
@@ -58,12 +55,12 @@ public class AuthTokenServer {
     class Handler implements HttpHandler {
         @Override
         public void handle(HttpExchange exchange) throws IOException {
-            var response = gson.toJson(new Response(token))
+            var response = ServerClient.GSON.toJson(new Response(token))
                 .getBytes(StandardCharsets.UTF_8);
 
             var headers = exchange.getResponseHeaders();
             headers.add("Content-Type", "application/json;charset=utf-8");
-            headers.add("Access-Control-Allow-Origin", ServerClient.FRONTEND_ORIGIN);
+            headers.add("Access-Control-Allow-Origin", AuthTokenServer.this.draaftServices.webOrigin());
             exchange.sendResponseHeaders(200, response.length);
 
             var stream = exchange.getResponseBody();

--- a/src/main/java/draaft/client/DraaftServices.java
+++ b/src/main/java/draaft/client/DraaftServices.java
@@ -1,0 +1,31 @@
+package draaft.client;
+
+import net.fabricmc.loader.api.FabricLoader;
+import org.jetbrains.annotations.Nullable;
+
+import java.net.URI;
+
+public record DraaftServices(
+    URI apiBase,
+    URI webBase,
+    // note: the origin MUST NOT end with a trailing slash
+    String webOrigin
+) {
+    public final static DraaftServices DEFAULT = new DraaftServices(
+        URI.create("https://api.disrespec.tech/"),
+        URI.create("https://disrespec.tech/draaft/"),
+        "https://disrespec.tech"
+    );
+
+    public static @Nullable DraaftServices fromJvmArgs() {
+        if (System.getProperty("DRAAFT_DEV") != null || FabricLoader.getInstance().isDevelopmentEnvironment()) {
+            return new DraaftServices(
+                URI.create(System.getProperty("DRAAFT_API_BASE", "http://localhost:8000/")),
+                URI.create(System.getProperty("DRAAFT_WEB_BASE", "http://localhost:8080/")),
+                System.getProperty("DRAAFT_WEB_ORIGIN", "http://localhost:8080")
+            );
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/main/java/draaft/client/ServerClient.java
+++ b/src/main/java/draaft/client/ServerClient.java
@@ -1,16 +1,17 @@
 package draaft.client;
 
 import com.google.gson.Gson;
-import com.google.gson.JsonObject;
 import com.mojang.authlib.exceptions.AuthenticationException;
 import com.mojang.authlib.exceptions.AuthenticationUnavailableException;
 import com.mojang.authlib.exceptions.InvalidCredentialsException;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.util.Session;
 import net.minecraft.util.Util;
 import org.apache.commons.codec.binary.Base32;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.net.URI;
@@ -24,126 +25,155 @@ import java.time.Instant;
 import static draaft.draaft.MOD_ID;
 
 public class ServerClient {
-    private final String clientPassword;
+    public static final Gson GSON = new Gson();
 
-    private static final boolean LOCAL_TESTING = false;
-    private static final String WEBSITE_BASE_URI = (ServerClient.LOCAL_TESTING ? "http://localhost:8080" : "https://disrespec.tech");
-    private static final String API_BASE_TESTING = (ServerClient.LOCAL_TESTING ? "http://localhost:8000" : "https://api.disrespec.tech");
-
-
-    // TODO(me-nx): remove hardcoded URIs
-    public static final URI API_BASE_URI = URI.create(String.format("%s/", API_BASE_TESTING));
-    public static final URI FRONTEND_BASE_URI = URI.create(String.format("%s/draaft/", WEBSITE_BASE_URI));
-    public static final String FRONTEND_ORIGIN = WEBSITE_BASE_URI; // do not add a trailing slash
+    private final AuthTokenServer authTokenServer;
+    private final HttpClient httpClient;
+    private final String token;
 
     public static final Logger LOGGER = LogManager.getLogger(MOD_ID);
-    HttpClient httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
 
-    public String connectingStatus = null;
-    public long connectingStatusTimestamp = 0; // 0 indicates to only show on hover
+    public static String connectingStatus = null;
+    public static long connectingStatusTimestamp = 0; // 0 indicates to only show on hover
 
-    public static ServerClient INSTANCE = null;
+    private static @Nullable ServerClient INSTANCE = null;
 
-    public static ServerClient getInstance() {
-        if (INSTANCE == null) {
-            INSTANCE = new ServerClient();
-        }
+    public static @Nullable ServerClient getInstance() {
         return INSTANCE;
     }
 
-    public ServerClient() {
-        SecureRandom instanceStrong;
-        try {
-            instanceStrong = SecureRandom.getInstanceStrong();
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
-        byte[] randomBytes = new byte[15];
-        instanceStrong.nextBytes(randomBytes);
-        clientPassword = new Base32().encodeAsString(randomBytes) + "draaaaft";
+    private ServerClient(AuthTokenServer authTokenServer, HttpClient httpClient, String token) {
+        this.authTokenServer = authTokenServer;
+        this.httpClient = httpClient;
+        this.token = token;
     }
 
-    private void setConnectionText(String text) {
-        this.connectingStatus = text;
-        this.connectingStatusTimestamp = Instant.now().getEpochSecond();
+    public <T> HttpResponse<T> httpSend(HttpRequest request, HttpResponse.BodyHandler<T> bodyPublisher)
+        throws IOException, InterruptedException
+    {
+        ServerClient.LOGGER.debug("HTTP request to {}", request.uri());
+
+        return this.httpClient.send(request, bodyPublisher);
+    }
+
+    public HttpRequest.Builder httpRequest(URI uri) {
+        return HttpRequest.newBuilder(uri)
+            .header("token", this.token);
     }
 
     // thanks menx :)
-    public void draaftLogin(/* :) */) {
+    public static void login(DraaftServices draaftServices) {
+        if (INSTANCE != null) {
+            // If already logged in just open the browser link
+            INSTANCE.openWebLoginUri();
+
+            return;
+        }
+
         MinecraftClient inst = MinecraftClient.getInstance();
         Session session = inst.getSession();
         // okay: then we add a "generate room" button ingame and it gives you a key
         // https://sessionserver.mojang.com/session/minecraft/hasJoined?username=DesktopFolder&serverId=draaft2025server
 
-        this.setConnectionText("Contacting Minecraft auth server...");
+        var httpClient = HttpClient.newBuilder()
+            .version(HttpClient.Version.HTTP_1_1) // HTTP 2 is not supported by fastapi
+            .build();
+
+        var clientPassword = generateClientPassword();
+
+        LOGGER.info("Contacting Minecraft auth server...");
+
         try {
             inst.getSessionService().joinServer(session.getProfile(), session.getAccessToken(), clientPassword);
             LOGGER.info("draaft successfully joined server with clientPassword");
-        } catch (AuthenticationUnavailableException var3) {
-            LOGGER.warn("disconnect.loginFailedInfo: disconnect.loginFailedInfo.serversUnavailable");
-            this.setConnectionText("Error: Servers unavailable!");
+        } catch (AuthenticationUnavailableException e) {
+            LOGGER.warn("disconnect.loginFailedInfo: disconnect.loginFailedInfo.serversUnavailable", e);
+            setConnectionText("Error: Servers unavailable!");
             return;
-        } catch (InvalidCredentialsException var4) {
-            LOGGER.warn("disconnect.loginFailedInfo: disconnect.loginFailedInfo.invalidSession");
-            this.setConnectionText("Error: Invalid session!");
+        } catch (InvalidCredentialsException e) {
+            LOGGER.warn("disconnect.loginFailedInfo: disconnect.loginFailedInfo.invalidSession", e);
+            setConnectionText("Error: Invalid session!");
             return;
         } catch (AuthenticationException authenticationException) {
-            LOGGER.warn("disconnect.loginFailedInfo {}", authenticationException.getMessage());
-            this.setConnectionText(authenticationException.getMessage());
+            LOGGER.warn("disconnect.loginFailedInfo", authenticationException);
+            setConnectionText(authenticationException.getMessage());
             return;
         }
-        this.setConnectionText("Contacting drAAft server...");
+        LOGGER.info("Contacting drAAft server...");
         String username = session.getUsername();
 
-        JsonObject body = new JsonObject();
-        body.addProperty("serverID", clientPassword);
-        body.addProperty("username", username);
+        String body = GSON.toJson(new LoginRequest(clientPassword, username), LoginRequest.class);
 
         String clientToken;
         try {
-            final var remote = API_BASE_URI.resolve("authenticate");
+            final var remote = draaftServices.apiBase().resolve("authenticate");
             LOGGER.info("Connecting to {}", remote);
+
             var req = HttpRequest.newBuilder(remote)
-                    .POST(HttpRequest.BodyPublishers.ofString(body.toString()))
+                    .POST(HttpRequest.BodyPublishers.ofString(body))
                     .setHeader("Content-Type", "application/json")
                     .build();
+
             HttpResponse<String> resp = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
-            JsonObject result  = new Gson().fromJson(resp.body(), JsonObject.class);
-            var decodeRes = result.get("token");
-            if (decodeRes == null) {
-                LOGGER.warn("Could not get token from drAAft server result!");
-                this.setConnectionText("Error in drAAft server response!");
+
+            clientToken = GSON.fromJson(resp.body(), LoginResponse.class).token;
+
+            if (clientToken == null) {
+                LOGGER.error("Could not get token from drAAft server result!");
+                setConnectionText("Error in drAAft server response!");
                 return;
             }
-            clientToken = decodeRes.getAsString();
-        } catch (IOException | InterruptedException e) {
-            LOGGER.warn("Could not contact drAAft server: {}", e.getMessage());
-            this.setConnectionText("Error contacting drAAft server!");
+        } catch (Throwable e) {
+            LOGGER.error("Could not contact drAAft server: {}", e.getMessage());
+            setConnectionText("Error contacting drAAft server!");
             return;
         }
+
         LOGGER.info("Successfully authenticated with the server, received {} long client token", clientToken.length());
 
-        /*
-        try {
-            var req = HttpRequest.newBuilder(new URI("http://localhost:8000/room/create"))
-                    .GET()
-                    .setHeader("Content-Type", "application/json")
-                    .setHeader("token", clientToken)
-                    .build();
-            HttpResponse<String> resp = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
-            System.out.println("----- YOUR DRAAFT ROOM CODE! READY FOR JOINING :) (in 2027)");
-            System.out.println(resp.body());
-        } catch (IOException | InterruptedException | URISyntaxException e) {
-            throw new RuntimeException(e);
+        var authTokenServer = new AuthTokenServer(draaftServices, clientToken);
+
+        INSTANCE = new ServerClient(authTokenServer, httpClient, clientToken);
+
+        setConnectionText("Opening in browser...");
+        INSTANCE.openWebLoginUri();
+    }
+
+    private void openWebLoginUri() {
+        var uri = this.authTokenServer.webLoginUri();
+
+        // TODO(me-nx): display toasts, shift click tooltip
+
+        if (Screen.hasShiftDown()) {
+            MinecraftClient.getInstance().keyboard.setClipboard(uri);
+        } else {
+            Util.getOperatingSystem().open(uri);
         }
-        */
+    }
 
-        AuthTokenServer.get().token = clientToken;
+    private static String generateClientPassword() {
+        try {
+            SecureRandom instanceStrong = SecureRandom.getInstanceStrong();
 
-        Util.getOperatingSystem().open(
-            FRONTEND_BASE_URI.toString() + "?auth_port=%d".formatted(AuthTokenServer.get().port())
-        );
+            byte[] randomBytes = new byte[15];
+            instanceStrong.nextBytes(randomBytes);
 
-        this.setConnectionText("Opening in browser...");
+            return new Base32().encodeAsString(randomBytes) + "draaaaft";
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("Secure RNG not available", e);
+        }
+    }
+
+    private static void setConnectionText(String text) {
+        connectingStatus = text;
+        connectingStatusTimestamp = Instant.now().getEpochSecond();
+    }
+
+    // GSON can't deserialize to method-local classes
+    record LoginRequest(String serverID, String username) {}
+
+    // Minecraft's version of GSON can't deserialize to records
+    static class LoginResponse {
+        public String token;
     }
 }

--- a/src/main/java/draaft/client/gui/LoginButton.java
+++ b/src/main/java/draaft/client/gui/LoginButton.java
@@ -1,0 +1,49 @@
+package draaft.client.gui;
+
+import draaft.client.DraaftServices;
+import draaft.client.ServerClient;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.enchantment.Enchantments;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.text.LiteralText;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.BooleanSupplier;
+import java.util.function.Function;
+
+public class LoginButton extends ButtonWidget {
+    private final BooleanSupplier glintSupplier;
+    private final ItemStack item;
+    private final ItemStack itemWithGlint;
+
+    public LoginButton(int x, int y, Item guiItem, BooleanSupplier glintSupplier, DraaftServices draaftServices) {
+        super(x, y, 20, 20, LiteralText.EMPTY, (btn) -> ServerClient.login(draaftServices));
+
+        this.glintSupplier = glintSupplier;
+
+        this.item = new ItemStack(guiItem);
+
+        this.itemWithGlint = new ItemStack(guiItem);
+        // I mean... Of course a bucket has AQUA AFFINITY 10 ~ Matsenuc
+        this.itemWithGlint.addEnchantment(Enchantments.AQUA_AFFINITY, 10);
+    }
+
+    @Override
+    public void renderButton(MatrixStack matrices, int mouseX, int mouseY, float delta) {
+        super.renderButton(matrices, mouseX, mouseY, delta);
+
+        var client = MinecraftClient.getInstance();
+
+        int bucketTextureSize = 16;
+
+        client.getItemRenderer().renderInGui(
+            glintSupplier.getAsBoolean() ? itemWithGlint : item,
+            this.x + (this.width - bucketTextureSize) / 2,
+            this.y + (this.height - bucketTextureSize) / 2
+        );
+    }
+}

--- a/src/main/java/draaft/mixin/client/gui/TitleScreenMixin.java
+++ b/src/main/java/draaft/mixin/client/gui/TitleScreenMixin.java
@@ -1,16 +1,11 @@
 package draaft.mixin.client.gui;
 
+import draaft.client.DraaftServices;
 import draaft.client.ServerClient;
-import me.contaria.speedrunapi.util.TextUtil;
-import net.minecraft.client.MinecraftClient;
+import draaft.client.gui.LoginButton;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.TitleScreen;
-import net.minecraft.client.gui.widget.ButtonWidget;
-import net.minecraft.client.render.item.ItemRenderer;
 import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.enchantment.Enchantments;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
@@ -21,11 +16,15 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.time.Instant;
+import java.util.function.BooleanSupplier;
 
 @Mixin(TitleScreen.class)
 public abstract class TitleScreenMixin extends Screen {
     @Unique
     private static final String DEFAULT_BUTTON_HOVER = "drAAft Login";
+
+    @Unique
+    private BooleanSupplier anyButtonHovered;
 
     protected TitleScreenMixin(Text title) {
         super(title);
@@ -36,60 +35,61 @@ public abstract class TitleScreenMixin extends Screen {
             at = @At("TAIL")
     )
     private void addDraaftLoginButton(CallbackInfo info) {
-        int login_button_width = 20;
-        int login_button_heigh = 20;
-        // Can probably get these from the Bucket Item somehow but didn't bother
-        int bucket_texture_width = 16;
-        int bucket_texture_height = 16;
-        int single_player_button_y = this.height / 4 + 48;
-        int single_player_button_half_width = 100;
-        int horizontal_button_spacing = 4;
+        int singlePlayerButtonHalfWidth = 100;
+        int horizontalButtonSpacing = 4;
+        int btnX = this.width / 2 + singlePlayerButtonHalfWidth + horizontalButtonSpacing;
+        int baseBtnY = this.height / 4 + 48;
 
-        Item bucket_item = Items.BUCKET;
-        ItemStack stack = new ItemStack(bucket_item);
-        // I mean... Of course a bucket has AQUA AFFINITY 10
-        stack.addEnchantment(Enchantments.AQUA_AFFINITY, 10);
-        MinecraftClient minecraftClient = MinecraftClient.getInstance();
-        ItemRenderer itemRenderer = minecraftClient.getItemRenderer();
+        var btn = this.addButton(new LoginButton(
+            btnX,
+            baseBtnY,
+            Items.WATER_BUCKET,
+            () -> ServerClient.getInstance() != null,
+            DraaftServices.DEFAULT
+        ));
 
-        this.addButton(new ButtonWidget(
-            this.width / 2 + single_player_button_half_width + horizontal_button_spacing,
-            single_player_button_y,
-            login_button_width,
-            login_button_heigh,
-            LiteralText.EMPTY,
-            button -> { ServerClient.getInstance().draaftLogin(); })
-        {
-            @Override
-            public void renderButton(MatrixStack matrices, int mouseX, int mouseY, float delta) {
-                super.renderButton(matrices, mouseX, mouseY, delta);
+        var altDraaftServices = DraaftServices.fromJvmArgs();
 
-                itemRenderer.renderInGui(
-                    stack,
-                    this.x + (login_button_width - bucket_texture_width) / 2,
-                    this.y + (login_button_heigh - bucket_texture_height) / 2
-                );
+        LoginButton altBtn;
 
-                var inst = ServerClient.getInstance();
-                if (this.isHovered() || inst.connectingStatus != null) {
-                    String s = inst.connectingStatus;
-                    if (s == null) {
-                        s = DEFAULT_BUTTON_HOVER;
-                    }
-                    else {
-                        if (inst.connectingStatusTimestamp == 0 && !this.isHovered()) {
-                            // Timed out already, just return
-                            return;
-                        }
-                        long t = Instant.now().getEpochSecond();
-                        if (t - inst.connectingStatusTimestamp > 10) {
-                            inst.connectingStatusTimestamp = 0;
-                        }
-                    }
-                    // todo - I can probably make this more efficient? lol
-                    this.drawCenteredText(matrices, TitleScreenMixin.this.textRenderer, TextUtil.literal(s), this.x + this.width / 2, this.y - 15, 16777215);
+        if (altDraaftServices != null) {
+            altBtn = this.addButton(new LoginButton(
+                btnX,
+                baseBtnY + 24,
+                Items.LAVA_BUCKET,
+                () -> ServerClient.getInstance() != null,
+                altDraaftServices
+            ));
+        } else {
+            altBtn = null;
+        }
+
+        this.anyButtonHovered = () -> altBtn != null ? (btn.isHovered() || altBtn.isHovered()) : btn.isHovered();
+    }
+
+    @Inject(method = "render", at = @At("TAIL"))
+    private void render(MatrixStack matrices, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+        // TODO(me-nx): switch to toasts
+        int x = this.width / 2 + 104;
+        int y = this.height / 4 + 48;
+
+        if (this.anyButtonHovered.getAsBoolean() || ServerClient.connectingStatus != null) {
+            String s = ServerClient.connectingStatus;
+            if (s == null) {
+                s = DEFAULT_BUTTON_HOVER;
+            }
+            else {
+                if (ServerClient.connectingStatusTimestamp == 0 && !this.anyButtonHovered.getAsBoolean()) {
+                    // Timed out already, just return
+                    return;
+                }
+                long t = Instant.now().getEpochSecond();
+                if (t - ServerClient.connectingStatusTimestamp > 10) {
+                    ServerClient.connectingStatusTimestamp = 0;
                 }
             }
-        });
+
+            this.drawCenteredText(matrices, TitleScreenMixin.this.textRenderer, new LiteralText(s), x + 10, y - 15, 0xffffff);
+        }
     }
 }


### PR DESCRIPTION
<img width="125" height="134" alt="image" src="https://github.com/user-attachments/assets/33bf7735-fbcb-4afd-97e4-8b3f8cb43279" />

Added a second button for development mode local frontend & API, enabled by a JVM property (`-DDRAAFT_DEV` in JVM args). Default dev-mode URIs are also overridable by JVM properties (see DraaftServices.java).

Refactored ServerClient, notably now it's created when the user logs in.