### PR TITLE
Update the minimum java version in fabric.mod.json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,6 +20,6 @@
   "depends": {
     "fabricloader": ">=0.16.13",
     "minecraft": "~1.16.1",
-    "java": ">=8"
+    "java": ">=16"
   }
 }


### PR DESCRIPTION
Note that drAAft doesn't load on lower versions anyway, with this change instead of a `UnsupportedClassVersionError` crash you get a nice fabric gui.