### PR TITLE
Disable peaceful

### DIFF
--- a/src/main/java/draaft/client/ModConfig.java
+++ b/src/main/java/draaft/client/ModConfig.java
@@ -1,0 +1,27 @@
+package draaft.client;
+
+import me.contaria.speedrunapi.config.api.SpeedrunConfig;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+
+import static draaft.draaft.MOD_ID;
+
+@Environment(EnvType.CLIENT) // SpeedrunAPI fails to load on servers
+public class ModConfig implements SpeedrunConfig {
+    public boolean disablePeaceful = true;
+
+    private static ModConfig instance;
+
+    public static ModConfig getInstance() {
+        return instance;
+    }
+
+    @Override
+    public String modID() {
+        return MOD_ID;
+    }
+
+    {
+        ModConfig.instance = this;
+    }
+}

--- a/src/main/java/draaft/mixin/client/gui/screen/options/OptionsScreenAccessor.java
+++ b/src/main/java/draaft/mixin/client/gui/screen/options/OptionsScreenAccessor.java
@@ -1,0 +1,24 @@
+package draaft.mixin.client.gui.screen.options;
+
+import net.minecraft.client.gui.screen.options.OptionsScreen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.text.Text;
+import net.minecraft.world.Difficulty;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(OptionsScreen.class)
+public interface OptionsScreenAccessor {
+    @Accessor("difficulty")
+    Difficulty draaft$difficulty();
+
+    @Accessor("difficulty")
+    void draaft$setDifficulty(Difficulty difficulty);
+
+    @Accessor("difficultyButton")
+    ButtonWidget draaft$difficultyButton();
+
+    @Invoker("getDifficultyButtonText")
+    Text draaft$getDifficultyButtonText(Difficulty difficulty);
+}

--- a/src/main/java/draaft/mixin/client/gui/screen/options/OptionsScreenMixin.java
+++ b/src/main/java/draaft/mixin/client/gui/screen/options/OptionsScreenMixin.java
@@ -1,6 +1,8 @@
 package draaft.mixin.client.gui.screen.options;
 
+import draaft.client.ModConfig;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.options.OptionsScreen;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.network.packet.c2s.play.UpdateDifficultyC2SPacket;
@@ -15,38 +17,61 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import java.util.Objects;
 
 @Mixin(OptionsScreen.class)
-public abstract class OptionsScreenMixin {
+public abstract class OptionsScreenMixin extends Screen {
+    @Unique
+    private final OptionsScreenAccessor self = (OptionsScreenAccessor)this;
+
+    @Unique
+    private Difficulty originalDifficulty;
+
     @Unique
     private boolean pseudoPeacefulSelected = false;
 
+    private OptionsScreenMixin(Text title) {
+        super(title);
+    }
+
     @Redirect(method = "init", at = @At(value = "NEW", ordinal = 0, target = "Lnet/minecraft/client/gui/widget/ButtonWidget;"))
     ButtonWidget difficultyButton(int x, int y, int width, int height, Text message, ButtonWidget.PressAction onPress) {
-        var self = (OptionsScreenAccessor)this;
+        if (!ModConfig.getInstance().disablePeaceful) {
+            return new ButtonWidget(x, y, width, height, message, onPress);
+        }
+
+        // this instance is reused when one of the option subscreens is closed
+        if (!this.pseudoPeacefulSelected) {
+            this.originalDifficulty = self.draaft$difficulty();
+        } else {
+            this.pseudoPeacefulSelected = false;
+        }
 
         return new ButtonWidget(x, y, width, height, message, (btn) -> {
-            if (self.draaft$difficulty() == Difficulty.HARD) {
-                pseudoPeacefulSelected = !pseudoPeacefulSelected;
-
-                if (!pseudoPeacefulSelected) {
-                    // PEACEFUL + 1 = EASY
-                    self.draaft$setDifficulty(Difficulty.PEACEFUL);
-                }
-            }
-
-            if (!pseudoPeacefulSelected) {
-                self.draaft$setDifficulty(Difficulty.byOrdinal(self.draaft$difficulty().getId() + 1));
-
-                Objects.requireNonNull(MinecraftClient.getInstance().getNetworkHandler())
-                    .sendPacket(new UpdateDifficultyC2SPacket(self.draaft$difficulty()));
+            if (this.pseudoPeacefulSelected) {
+                this.switchTo(Difficulty.EASY);
+                this.pseudoPeacefulSelected = false;
 
                 self.draaft$difficultyButton().setMessage(self.draaft$getDifficultyButtonText(self.draaft$difficulty()));
-            } else {
+            } else if (self.draaft$difficulty() == Difficulty.HARD) {
+                this.switchTo(this.originalDifficulty);
+                this.pseudoPeacefulSelected = true;
+
                 self.draaft$difficultyButton().setMessage(
                     new TranslatableText("options.difficulty")
                         .append(": ")
                         .append(new TranslatableText("draaft.game.options.pseudoPeaceful"))
                 );
+            } else {
+                this.switchTo(Difficulty.byOrdinal(self.draaft$difficulty().getId() + 1));
+
+                self.draaft$difficultyButton().setMessage(self.draaft$getDifficultyButtonText(self.draaft$difficulty()));
             }
         });
+    }
+
+    @Unique
+    private void switchTo(Difficulty difficulty) {
+        self.draaft$setDifficulty(difficulty);
+
+        Objects.requireNonNull(MinecraftClient.getInstance().getNetworkHandler())
+            .sendPacket(new UpdateDifficultyC2SPacket(difficulty));
     }
 }

--- a/src/main/java/draaft/mixin/client/gui/screen/options/OptionsScreenMixin.java
+++ b/src/main/java/draaft/mixin/client/gui/screen/options/OptionsScreenMixin.java
@@ -1,0 +1,52 @@
+package draaft.mixin.client.gui.screen.options;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.options.OptionsScreen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.network.packet.c2s.play.UpdateDifficultyC2SPacket;
+import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
+import net.minecraft.world.Difficulty;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.Objects;
+
+@Mixin(OptionsScreen.class)
+public abstract class OptionsScreenMixin {
+    @Unique
+    private boolean pseudoPeacefulSelected = false;
+
+    @Redirect(method = "init", at = @At(value = "NEW", ordinal = 0, target = "Lnet/minecraft/client/gui/widget/ButtonWidget;"))
+    ButtonWidget difficultyButton(int x, int y, int width, int height, Text message, ButtonWidget.PressAction onPress) {
+        var self = (OptionsScreenAccessor)this;
+
+        return new ButtonWidget(x, y, width, height, message, (btn) -> {
+            if (self.draaft$difficulty() == Difficulty.HARD) {
+                pseudoPeacefulSelected = !pseudoPeacefulSelected;
+
+                if (!pseudoPeacefulSelected) {
+                    // PEACEFUL + 1 = EASY
+                    self.draaft$setDifficulty(Difficulty.PEACEFUL);
+                }
+            }
+
+            if (!pseudoPeacefulSelected) {
+                self.draaft$setDifficulty(Difficulty.byOrdinal(self.draaft$difficulty().getId() + 1));
+
+                Objects.requireNonNull(MinecraftClient.getInstance().getNetworkHandler())
+                    .sendPacket(new UpdateDifficultyC2SPacket(self.draaft$difficulty()));
+
+                self.draaft$difficultyButton().setMessage(self.draaft$getDifficultyButtonText(self.draaft$difficulty()));
+            } else {
+                self.draaft$difficultyButton().setMessage(
+                    new TranslatableText("options.difficulty")
+                        .append(": ")
+                        .append(new TranslatableText("draaft.game.options.pseudoPeaceful"))
+                );
+            }
+        });
+    }
+}

--- a/src/main/resources/assets/draaft/lang/en_us.json
+++ b/src/main/resources/assets/draaft/lang/en_us.json
@@ -17,5 +17,8 @@
   "draaft.draaftingScreen.button.copy": "Copy",
   "draaft.draaftingScreen.button.ready": "Ready Up",
   "draaft.draaftingScreen.button.nextStage": "Next Stage",
-  "draaft.game.options.pseudoPeaceful": "Peaceless"
+  "draaft.game.options.pseudoPeaceful": "Peaceless",
+
+  "speedrunapi.config.draaft.option.disablePeaceful": "Disable Peaceful",
+  "speedrunapi.config.draaft.option.disablePeaceful.description": "Prevents accidentally switching to peaceful in game options."
 }

--- a/src/main/resources/assets/draaft/lang/en_us.json
+++ b/src/main/resources/assets/draaft/lang/en_us.json
@@ -16,5 +16,6 @@
   "draaft.draaftingScreen.tooltip.revealRoomCode": "Click to reveal room code",
   "draaft.draaftingScreen.button.copy": "Copy",
   "draaft.draaftingScreen.button.ready": "Ready Up",
-  "draaft.draaftingScreen.button.nextStage": "Next Stage"
+  "draaft.draaftingScreen.button.nextStage": "Next Stage",
+  "draaft.game.options.pseudoPeaceful": "Peaceless"
 }

--- a/src/main/resources/draaft.mixins.json
+++ b/src/main/resources/draaft.mixins.json
@@ -36,6 +36,8 @@
   "client": [
     "compat.InGameTimerMixin",
     "client.gui.DebugHudMixin",
-    "client.gui.TitleScreenMixin"
+    "client.gui.TitleScreenMixin",
+    "client.gui.screen.options.OptionsScreenAccessor",
+    "client.gui.screen.options.OptionsScreenMixin"
   ]
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "draaft",
   "version": "${version}",
-  "name": "draaft",
+  "name": "drAAft",
   "description": "Mod for Pac's awesome AA Event",
   "authors": ["Memerson", "PacManMVC"],
   "contact": {
@@ -21,5 +21,10 @@
     "fabricloader": ">=0.16.13",
     "minecraft": "~1.16.1",
     "java": ">=16"
+  },
+  "custom": {
+    "speedrunapi": {
+      "config": "draaft.client.ModConfig"
+    }
   }
 }


### PR DESCRIPTION
Unlike nopeaceful this shouldn't interfere with muscle memory. When clicked on hard it stays on hard but waits for a second click to switch to easy.

1.
<img width="315" height="64" alt="hard" src="https://github.com/user-attachments/assets/ac3e7fb5-61aa-4df0-965c-5d5358c6801b" />

2.
<img width="315" height="64" alt="pseudo peaceful" src="https://github.com/user-attachments/assets/9b20f797-8a84-4f85-acde-071914435df0" />

3.
<img width="311" height="59" alt="easy" src="https://github.com/user-attachments/assets/703fd675-345a-4364-909a-c59b2ccf88f5" />
