### PR TITLE
Fix loading on servers

### DIFF
--- a/src/main/resources/draaft.mixins.json
+++ b/src/main/resources/draaft.mixins.json
@@ -3,7 +3,6 @@
   "package": "draaft.mixin",
   "compatibilityLevel": "JAVA_11",
   "mixins": [
-    "compat.InGameTimerMixin",
     "enchantment.EnchantmentsMixin",
     "entity.boss.dragon.EnderDragonEntityMixin",
     "entity.boss.dragon.phase.HoldingPatternPhaseMixin",
@@ -35,6 +34,7 @@
     "defaultRequire": 1
   },
   "client": [
+    "compat.InGameTimerMixin",
     "client.gui.DebugHudMixin",
     "client.gui.TitleScreenMixin"
   ]


### PR DESCRIPTION
(draaft has to load on servers for pregening to work)

SpeedrunAPI currently breaks runServer, but otherwise if you remove the jar / switch to `modCompileOnly` draaft loads.